### PR TITLE
My Grades in main event nav

### DIFF
--- a/src/com/page/nav/event.js
+++ b/src/com/page/nav/event.js
@@ -30,9 +30,9 @@ export default class PageNavEvent extends Component {
 		NavButtons.push(<ContentNavButton path={path+FirstPath} icon="ticket" href={path+'/theme'}>Theme</ContentNavButton>);
 		NavButtons.push(<ContentNavButton path={path+FullPath} icon="stats" href={path+'/stats'}>Stats</ContentNavButton>);
 
-		if ( IsLoggedIn ) {
+		if ( IsLoggedIn && ThemeMode >= 6 ) {
 			/* light={FirstPath == '/my'} */
-			NavButtons.push(<ContentNavButton path={path+FirstPath} icon="user" href={path+'/my'}>Me</ContentNavButton>);
+			NavButtons.push(<ContentNavButton path={path+FullPath} icon="star-half" href={path+'/my/grades'}>My Grades</ContentNavButton>);
 		}
 
 //		// "Me" User Button (if home or logged in)


### PR DESCRIPTION
Putting `My Grades` button in the main event nav when mode reaches the opening of voting.

![image](https://user-images.githubusercontent.com/8041100/44644400-3a3c6e80-a9d4-11e8-9de2-8da015f80119.png)

The me-nav lingers only when actually visiting the my grades-page otherwise it is removed. It's rather useless at the moment so perhaps even better dropping it entierly?